### PR TITLE
Print decimal point and symbol when querying erc20 balance

### DIFF
--- a/x/bridge/client/cli/query.go
+++ b/x/bridge/client/cli/query.go
@@ -252,7 +252,29 @@ func QueryERC20BalanceOfCmd() *cobra.Command {
 				return fmt.Errorf("invalid type %T, expected %T", anyOutput[0], bal)
 			}
 
-			return clientCtx.PrintString(fmt.Sprintf("%v\n", bal))
+			symbolRes, err := ERC20Query(clientCtx, contractAddr, "symbol")
+			if err != nil {
+				return err
+			}
+
+			decimalsRes, err := ERC20Query(clientCtx, contractAddr, "decimals")
+			if err != nil {
+				return err
+			}
+
+			symbol, ok := symbolRes[0].(string)
+			if !ok {
+				return fmt.Errorf("invalid type %T, expected %T", symbolRes[0], symbol)
+			}
+
+			decimals, ok := decimalsRes[0].(uint8)
+			if !ok {
+				return fmt.Errorf("invalid type %T, expected %T", decimalsRes[0], decimals)
+			}
+
+			decBal := sdk.NewDecFromBigIntWithPrec(bal, int64(decimals))
+
+			return clientCtx.PrintString(fmt.Sprintf("%v %v\n", decBal, symbol))
 		},
 	}
 }


### PR DESCRIPTION
```bash
# before
$ kava-bridged q bridge erc20-balance 0x404F9466d758eA33eA84CeBE9E444b06533b369e 
1000000000000000001

# after
$ kava-bridged q bridge erc20-balance 0x404F9466d758eA33eA84CeBE9E444b06533b369e 
1.000000000000000001 WETH
```