### PR TITLE
Allow nil relayer in params, check before minting

### DIFF
--- a/x/bridge/genesis_test.go
+++ b/x/bridge/genesis_test.go
@@ -75,7 +75,7 @@ func (suite *genesisTestSuite) Test_InitGenesis_Validation() {
 			},
 		},
 		{
-			"invalid - nil relayer",
+			"valid - nil relayer",
 			types.NewGenesisState(
 				types.NewParams(
 					true,
@@ -107,8 +107,7 @@ func (suite *genesisTestSuite) Test_InitGenesis_Validation() {
 				types.DefaultNextWithdrawSequence,
 			),
 			errArgs{
-				expectPass: false,
-				panicErr:   "value from ParamSetPair is invalid: relayer address cannot be nil",
+				expectPass: true,
 			},
 		},
 		{

--- a/x/bridge/keeper/erc20.go
+++ b/x/bridge/keeper/erc20.go
@@ -27,6 +27,10 @@ func (k Keeper) BridgeEthereumToKava(
 		return types.ErrBridgeDisabled
 	}
 
+	if params.Relayer.Empty() {
+		return types.ErrNoRelayer
+	}
+
 	// Check if message signer/relayer matches the relayer set in params
 	if err := k.IsSignerAuthorized(ctx, relayer); err != nil {
 		return err

--- a/x/bridge/keeper/msg_server_test.go
+++ b/x/bridge/keeper/msg_server_test.go
@@ -123,6 +123,26 @@ func (suite *MsgServerSuite) TestBridgeEthereumToKava() {
 	}
 }
 
+func (suite *MsgServerSuite) TestBridgeEthereumToKava_NilRelayer() {
+	// Set relayer to nil
+	params := suite.Keeper.GetParams(suite.Ctx)
+	params.Relayer = nil
+	suite.Keeper.SetParams(suite.Ctx, params)
+
+	msg := types.NewMsgBridgeEthereumToKava(
+		suite.RelayerAddress.String(),
+		"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+		sdk.NewInt(1234),
+		"0x4A59E9DDB116A04C5D40082D67C738D5C56DF124",
+		sdk.NewInt(1),
+	)
+
+	_, err := suite.msgServer.BridgeEthereumToKava(sdk.WrapSDKContext(suite.Ctx), &msg)
+
+	suite.Require().Error(err)
+	suite.Require().ErrorIs(err, types.ErrNoRelayer)
+}
+
 func (suite *MsgServerSuite) TestBridgeEthereumToKava_BridgeDisabled() {
 	// Disable bridge
 	params := suite.Keeper.GetParams(suite.Ctx)

--- a/x/bridge/types/errors.go
+++ b/x/bridge/types/errors.go
@@ -12,4 +12,5 @@ var (
 	ErrInvalidInitialWithdrawSequence = sdkerrors.Register(ModuleName, 5, "initial withdraw sequence hasn't been set")
 	ErrConversionNotEnabled           = sdkerrors.Register(ModuleName, 6, "ERC20 token not enabled to convert to sdk.Coin")
 	ErrBridgeDisabled                 = sdkerrors.Register(ModuleName, 7, "Bridge transactions and conversions are disabled")
+	ErrNoRelayer                      = sdkerrors.Register(ModuleName, 8, "There is no relayer set")
 )

--- a/x/bridge/types/params.go
+++ b/x/bridge/types/params.go
@@ -3,7 +3,6 @@ package types
 import (
 	bytes "bytes"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"math"
 
@@ -20,7 +19,6 @@ var (
 	KeyEnabledConversionPairs = []byte("EnabledConversionPairs")
 	DefaultBridgeEnabled      = false
 	DefaultEnabledERC20Tokens = EnabledERC20Tokens{}
-	DefaultRelayer            = sdk.AccAddress{}
 	DefaultConversionPairs    = ConversionPairs{}
 )
 
@@ -60,24 +58,22 @@ func DefaultParams() Params {
 	return NewParams(
 		DefaultBridgeEnabled,
 		DefaultEnabledERC20Tokens,
-		DefaultRelayer,
+		nil,
 		DefaultConversionPairs,
 	)
 }
 
+// Validate returns an error if the Parmas is invalid.
 func (p *Params) Validate() error {
 	if err := p.EnabledERC20Tokens.Validate(); err != nil {
 		return err
-	}
-
-	if p.Relayer == nil {
-		return errors.New("relayer cannot be nil")
 	}
 
 	if err := p.EnabledConversionPairs.Validate(); err != nil {
 		return err
 	}
 
+	// Empty or nil value for Relayer is valid
 	return nil
 }
 
@@ -185,15 +181,12 @@ func (e EnabledERC20Token) Validate() error {
 	return nil
 }
 
-// validateRelayer validates a relayer address
+// validateRelayer validates a relayer address is the right type
 func validateRelayer(i interface{}) error {
-	relayerAddr, ok := i.(sdk.AccAddress)
+	// Empty or nil values are valid
+	_, ok := i.(sdk.AccAddress)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
-	if relayerAddr == nil {
-		return errors.New("relayer address cannot be nil")
 	}
 
 	return nil

--- a/x/bridge/types/params.go
+++ b/x/bridge/types/params.go
@@ -13,13 +13,14 @@ import (
 
 // Parameter keys and default values
 var (
-	KeyBridgeEnabled          = []byte("BridgeEnabled")
-	KeyEnabledERC20Tokens     = []byte("EnabledERC20Tokens")
-	KeyRelayer                = []byte("Relayer")
-	KeyEnabledConversionPairs = []byte("EnabledConversionPairs")
-	DefaultBridgeEnabled      = false
-	DefaultEnabledERC20Tokens = EnabledERC20Tokens{}
-	DefaultConversionPairs    = ConversionPairs{}
+	KeyBridgeEnabled                         = []byte("BridgeEnabled")
+	KeyEnabledERC20Tokens                    = []byte("EnabledERC20Tokens")
+	KeyRelayer                               = []byte("Relayer")
+	KeyEnabledConversionPairs                = []byte("EnabledConversionPairs")
+	DefaultBridgeEnabled                     = false
+	DefaultEnabledERC20Tokens                = EnabledERC20Tokens{}
+	DefaultRelayer            sdk.AccAddress = nil
+	DefaultConversionPairs                   = ConversionPairs{}
 )
 
 // ParamKeyTable for bridge module.
@@ -58,7 +59,7 @@ func DefaultParams() Params {
 	return NewParams(
 		DefaultBridgeEnabled,
 		DefaultEnabledERC20Tokens,
-		nil,
+		DefaultRelayer,
 		DefaultConversionPairs,
 	)
 }

--- a/x/bridge/types/params_test.go
+++ b/x/bridge/types/params_test.go
@@ -58,6 +58,24 @@ func (suite *ParamsTestSuite) TestParamValidation() {
 			},
 		},
 		{
+			"valid - nil address",
+			args{
+				enabledERC20Tokens: types.EnabledERC20Tokens{
+					types.NewEnabledERC20Token(
+						testutil.MustNewExternalEVMAddressFromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+						"Wrapped Ether",
+						"WETH",
+						18,
+						testutil.MinWETHWithdrawAmount,
+					),
+				},
+				relayer: nil,
+			},
+			errArgs{
+				expectPass: true,
+			},
+		},
+		{
 			"invalid - duplicate token address",
 			args{
 				enabledERC20Tokens: types.EnabledERC20Tokens{
@@ -179,25 +197,6 @@ func (suite *ParamsTestSuite) TestParamValidation() {
 			},
 		},
 		{
-			"invalid - nil address",
-			args{
-				enabledERC20Tokens: types.EnabledERC20Tokens{
-					types.NewEnabledERC20Token(
-						testutil.MustNewExternalEVMAddressFromString("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
-						"Wrapped Ether",
-						"WETH",
-						18,
-						testutil.MinWETHWithdrawAmount,
-					),
-				},
-				relayer: nil,
-			},
-			errArgs{
-				expectPass: false,
-				contains:   "relayer cannot be nil",
-			},
-		},
-		{
 			"invalid - zero minimum_withdraw_amount",
 			args{
 				enabledERC20Tokens: types.EnabledERC20Tokens{
@@ -264,7 +263,7 @@ func (suite *ParamsTestSuite) TestDefault() {
 
 	suite.Require().Empty(defaultParams.EnabledERC20Tokens)
 	suite.Require().Equal(types.DefaultEnabledERC20Tokens, defaultParams.EnabledERC20Tokens)
-	suite.Require().Equal(types.DefaultRelayer, defaultParams.Relayer)
+	suite.Require().Nil(defaultParams.Relayer)
 }
 
 func (suite *ParamsTestSuite) TestUnmarshalJSON() {

--- a/x/bridge/types/params_test.go
+++ b/x/bridge/types/params_test.go
@@ -263,7 +263,7 @@ func (suite *ParamsTestSuite) TestDefault() {
 
 	suite.Require().Empty(defaultParams.EnabledERC20Tokens)
 	suite.Require().Equal(types.DefaultEnabledERC20Tokens, defaultParams.EnabledERC20Tokens)
-	suite.Require().Nil(defaultParams.Relayer)
+	suite.Require().Equal(types.DefaultRelayer, defaultParams.Relayer)
 }
 
 func (suite *ParamsTestSuite) TestUnmarshalJSON() {


### PR DESCRIPTION
* Adds check for empty relayer before minting.
* Removes relayer nil check in params Validate() -- this actually didn't seem to be doing anything as setting relayer to `null` in genesis.json still worked and was changed to an empty string "" when queried.
* Sets the default relayer to nil instead of an empty sdk.AccAddress