### PR TITLE
Add eth tx hash to bridge withdraw event

### DIFF
--- a/x/bridge/keeper/evm_withdraw_hooks.go
+++ b/x/bridge/keeper/evm_withdraw_hooks.go
@@ -146,6 +146,7 @@ func (h WithdrawHook) PostTxProcessing(
 			sdk.NewAttribute(types.AttributeKeyReceiver, toAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, amount.String()),
 			sdk.NewAttribute(types.AttributeKeySequence, sequence.String()),
+			sdk.NewAttribute(types.AttributeKeyTxHash, receipt.TxHash.String()),
 		))
 	}
 

--- a/x/bridge/keeper/evm_withdraw_hooks_test.go
+++ b/x/bridge/keeper/evm_withdraw_hooks_test.go
@@ -295,7 +295,7 @@ func (suite *EVMHooksTestSuite) TestERC20Withdraw_EmitsEvent() {
 	withdrawAmount := testutil.MinWETHWithdrawAmount.BigInt()
 
 	// Send Withdraw TX
-	_ = suite.Withdraw(suite.pair.GetInternalAddress(), withdrawToAddr, withdrawAmount)
+	res := suite.Withdraw(suite.pair.GetInternalAddress(), withdrawToAddr, withdrawAmount)
 
 	suite.EventsContains(suite.GetEvents(),
 		sdk.NewEvent(
@@ -305,10 +305,11 @@ func (suite *EVMHooksTestSuite) TestERC20Withdraw_EmitsEvent() {
 			sdk.NewAttribute(types.AttributeKeyReceiver, withdrawToAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, withdrawAmount.String()),
 			sdk.NewAttribute(types.AttributeKeySequence, "1"),
+			sdk.NewAttribute(types.AttributeKeyTxHash, res.Hash),
 		))
 
 	// Second withdraw tx
-	_ = suite.Withdraw(suite.pair.GetInternalAddress(), withdrawToAddr, withdrawAmount)
+	res = suite.Withdraw(suite.pair.GetInternalAddress(), withdrawToAddr, withdrawAmount)
 
 	// Second one has incremented sequence
 	suite.EventsContains(suite.GetEvents(),
@@ -319,6 +320,7 @@ func (suite *EVMHooksTestSuite) TestERC20Withdraw_EmitsEvent() {
 			sdk.NewAttribute(types.AttributeKeyReceiver, withdrawToAddr.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, withdrawAmount.String()),
 			sdk.NewAttribute(types.AttributeKeySequence, "2"),
+			sdk.NewAttribute(types.AttributeKeyTxHash, res.Hash),
 		))
 }
 

--- a/x/bridge/types/events.go
+++ b/x/bridge/types/events.go
@@ -23,6 +23,7 @@ const (
 	AttributeKeyKavaERC20Address     = "kava_erc20_address"
 	AttributeKeyRelayer              = "relayer"
 	AttributeKeySequence             = "sequence"
+	AttributeKeyTxHash               = "tx_hash"
 
 	// Event Attributes - Conversions
 	AttributeKeyInitiator    = "initiator"


### PR DESCRIPTION
This is used to find the corresponding withdraw event to get the withdraw sequence.